### PR TITLE
Check and replace percent encoded `:` when provisioning domain

### DIFF
--- a/did_tdw/provision.py
+++ b/did_tdw/provision.py
@@ -53,6 +53,12 @@ async def auto_provision_did(
         next_key_hash = None
     state = provision_did(genesis, params=params, hash_name=hash_name)
     doc_id = state.document_id
+    # Check for percent-encoded domain name
+    domain = doc_id.split(":")[-1]
+    if "%3A" in domain:
+        domain = domain.replace("%3A", ":")
+        doc_id = doc_id.rsplit(":", 1)[0] + ":" + domain
+
     doc_dir = Path(doc_id)
     doc_dir.mkdir(exist_ok=False)
 


### PR DESCRIPTION
In the spec you can use percent encoding to create a domain that contains a port. This is useful for testing locally without setting up a complex domain mapping. However the provision method wouldn't allow this because of the percent symbol in the filepath of the sqlite askar store. 

Replacing the encoded value allows the domain to contain a port and easily provision the store.