### PR TITLE
Publish workflows

### DIFF
--- a/.github/actions/unit-tests/action.yml
+++ b/.github/actions/unit-tests/action.yml
@@ -1,0 +1,27 @@
+name: Run Unit tests
+description: Run unit tests on the codebase
+
+inputs:
+  with-coverage:
+    description: 'Whether to run tests with coverage'
+    required: false
+    default: 'false'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - name: Install dependencies
+      shell: bash
+      run: pip install poetry && poetry install
+    - name: Run unit tests
+      shell: bash
+      run: | 
+        if [ "${{ inputs.with-coverage }}" = "true" ]; then
+          poetry run pytest --cov .
+        else
+          poetry run pytest
+        fi

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,33 @@
+name: Publish to PyPI
+
+on:
+  workflow_dispatch:
+
+jobs:
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/trustdidweb-py
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Run Tests
+        uses: ./.github/actions/unit-tests
+        with :
+          with-coverage: false
+      - name: Install build and publish dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine poetry
+      - name: Build and publish
+        run: |
+          poetry build
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,23 @@
+name: Unit Tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4
+    - name: Tests
+      uses: ./.github/actions/unit-tests
+      with:
+        with-coverage: true


### PR DESCRIPTION
This PR adds a github action for running the unit tests and two workflows. One for the unit tests to run on PR's opening and changing or by manual dispatch. The other is for publishing to pypi. It will run the unit tests and then build and publish with twine.

The publish requires the pypi account owner where the library is published to setup the github action authentication.

![image](https://github.com/user-attachments/assets/4dfa2db5-4543-4d9d-b68d-fcce225686f3)

project_name: did-tdw
owner: github account username
repository name: trustdidweb-py
workflow name: publish-pypi.yml
environment: optional (leave blank)