### PR TITLE
Fixes failing negative test of DID Log Entry lacking sufficient witness signatures

### DIFF
--- a/did_webvh/core/witness.py
+++ b/did_webvh/core/witness.py
@@ -59,6 +59,14 @@ class WitnessRule:
         if not isinstance(witnesses, list):
             raise ValueError("Expected list for 'witnesses' in 'witness' value")
         witnesses = tuple(WitnessEntry.deserialize(w) for w in witnesses)
+        if witnesses and threshold < 1:
+            raise ValueError(
+                "Expected 'threshold' of at least 1 when 'witnesses' is non-empty"
+            )
+        if threshold > len(witnesses):
+            raise ValueError(
+                "Expected 'threshold' no greater than the number of 'witnesses'"
+            )
         return WitnessRule(threshold, witnesses)
 
 


### PR DESCRIPTION
Addresses the last remaining failing test with the [didwebvh-test-suite](https://github.com/decentralized-identity/didwebvh-test-suite) -- the `negative-zero-witness-threshold` test.  In the test {per the [test description](https://github.com/decentralized-identity/didwebvh-test-suite/blob/main/vectors/negative-zero-witness-threshold/README.md)):

> The DID controller publishes a witness config with `threshold: 0` (or a negative integer, or a non-integer such as a string or `null`) alongside a non-empty witnesses list. In implementations that use a permissive parser (serde untagged enum, Zod `.or()`, etc.), the malformed-but-non-empty value falls through to the "empty / no witnesses" arm and witness validation is silently disabled for the DID — even though the controller is presenting a witness list as if witnessing is in effect.

Once we get this PR merged (assuming it is OK), we'll release version 1.0.1 to get the Python implementation fully spec-compliant and interoperable with the rest of the implementations.

